### PR TITLE
feat: Initial Terraform setup for Computer Use Demo

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -28,7 +28,11 @@ terraform plan
 terraform apply
 
 # Connect to the instance (replace with your actual IP)
-ssh -L 8080:localhost:8080 -i ~/.ssh/claude_aws_key ubuntu@<instance_public_ip>
+# IMPORTANT: Create SSH tunnel for ALL required services (RECOMMENDED METHOD)
+ssh -i ~/.ssh/claude_aws_key -L 8080:localhost:8080 -L 6080:localhost:6080 -L 5900:localhost:5900 -L 8501:localhost:8501 -N ubuntu@<instance_public_ip>
+
+# Simple tunnel (NOT RECOMMENDED - interface may not work properly)
+# ssh -L 8080:localhost:8080 -i ~/.ssh/claude_aws_key ubuntu@<instance_public_ip>
 
 # Access the Claude interface
 # Open http://localhost:8080 in your browser
@@ -36,6 +40,14 @@ ssh -L 8080:localhost:8080 -i ~/.ssh/claude_aws_key ubuntu@<instance_public_ip>
 # When finished, destroy all resources
 terraform destroy
 ```
+
+This tunneling command forwards all necessary ports:
+- 8080: Main Claude interface
+- 6080: noVNC web interface
+- 5900: VNC direct connection
+- 8501: Streamlit interface
+
+The `-N` flag prevents opening a shell and is useful for just forwarding ports.
 
 ### Resource Requirements
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,59 @@
+# Anthropic Quickstarts - Computer Use Demo
+
+## Repository Overview
+This repository contains quickstart projects for building applications with Anthropic's Claude. The main focus is on the **Computer Use Demo**, which demonstrates how Claude 3.5/3.7 Sonnet models can control a desktop computer.
+
+## Project Structure
+The primary directory we're working with is `computer-use-demo/`, which contains:
+- `terraform/`: Infrastructure as Code for deploying the demo on AWS EC2
+- Docker configuration for running the demo in a containerized environment
+
+## Terraform Deployment
+
+The `computer-use-demo/terraform/` directory contains a complete Terraform configuration for deploying Claude Computer Use Demo on AWS EC2. This allows you to run the demo in the cloud rather than locally.
+
+### Key Commands
+
+```bash
+# Navigate to the terraform directory
+cd computer-use-demo/terraform
+
+# Initialize Terraform
+terraform init
+
+# Preview changes before applying
+terraform plan
+
+# Deploy the infrastructure
+terraform apply
+
+# Connect to the instance (replace with your actual IP)
+ssh -L 8080:localhost:8080 -i ~/.ssh/claude_aws_key ubuntu@<instance_public_ip>
+
+# Access the Claude interface
+# Open http://localhost:8080 in your browser
+
+# When finished, destroy all resources
+terraform destroy
+```
+
+### Resource Requirements
+
+- EC2 instance type: At least t3.2xlarge recommended (t3.large may be insufficient)
+- The deployment includes VPC, security groups, and other necessary network components
+- Estimated cost: ~$240-300/month (t3.2xlarge running 24/7) or ~$80-100/month with scheduled stops
+
+## Computer Use Demo Overview
+
+The Computer Use Demo provides an environment where Claude can:
+- Control a virtual desktop running in a Docker container
+- Access web browsers and other applications
+- Interact with a graphical interface
+- Execute commands
+
+The Terraform deployment automatically sets up:
+- EC2 instance with Ubuntu 22.04
+- Docker installation
+- Container configuration with appropriate ports (8080, 8501, 6080, 5900)
+- Systemd service for auto-starting the container
+- API key configuration for Claude 

--- a/.cursorrules
+++ b/.cursorrules
@@ -29,10 +29,10 @@ terraform apply
 
 # Connect to the instance (replace with your actual IP)
 # IMPORTANT: Create SSH tunnel for ALL required services (RECOMMENDED METHOD)
-ssh -i ~/.ssh/claude_aws_key -L 8080:localhost:8080 -L 6080:localhost:6080 -L 5900:localhost:5900 -L 8501:localhost:8501 -N ubuntu@<instance_public_ip>
+ssh -i ~/.ssh/claude_aws_key -L 8080:127.0.0.1:8080 -L 6080:127.0.0.1:6080 -L 5900:127.0.0.1:5900 -L 8501:127.0.0.1:8501 -N ubuntu@<instance_public_ip>
 
 # Simple tunnel (NOT RECOMMENDED - interface may not work properly)
-# ssh -L 8080:localhost:8080 -i ~/.ssh/claude_aws_key ubuntu@<instance_public_ip>
+# ssh -L 8080:127.0.0.1:8080 -i ~/.ssh/claude_aws_key ubuntu@<instance_public_ip>
 
 # Access the Claude interface
 # Open http://localhost:8080 in your browser
@@ -69,3 +69,24 @@ The Terraform deployment automatically sets up:
 - Container configuration with appropriate ports (8080, 8501, 6080, 5900)
 - Systemd service for auto-starting the container
 - API key configuration for Claude 
+
+## Additional Options
+
+### Enable Thinking Mode
+
+You can enable "Thinking" mode by setting the `ENABLE_THINKING` environment variable to `true`:
+
+```bash
+# For local Docker execution
+docker run \
+    -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
+    -e ENABLE_THINKING=true \
+    -v $HOME/.anthropic:/home/computeruse/.anthropic \
+    -p 5900:5900 \
+    -p 8501:8501 \
+    -p 6080:6080 \
+    -p 8080:8080 \
+    -it ghcr.io/anthropics/anthropic-quickstarts:computer-use-demo-latest
+```
+
+The Terraform deployment already includes this flag. 

--- a/computer-use-demo/.gitignore
+++ b/computer-use-demo/.gitignore
@@ -2,3 +2,5 @@
 .ruff_cache
 __pycache__
 .pytest_cache
+
+temp/

--- a/computer-use-demo/README.md
+++ b/computer-use-demo/README.md
@@ -155,6 +155,24 @@ docker run \
     -it ghcr.io/anthropics/anthropic-quickstarts:computer-use-demo-latest
 ```
 
+## Enable Thinking Mode
+
+You can enable "Thinking" mode by setting the `ENABLE_THINKING` environment variable to `true`:
+
+```bash
+docker run \
+    -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
+    -e ENABLE_THINKING=true \
+    -v $HOME/.anthropic:/home/computeruse/.anthropic \
+    -p 5900:5900 \
+    -p 8501:8501 \
+    -p 6080:6080 \
+    -p 8080:8080 \
+    -it ghcr.io/anthropics/anthropic-quickstarts:computer-use-demo-latest
+```
+
+This will automatically check the "Thinking Enabled" option in the UI when the container starts.
+
 We do not recommend sending screenshots in resolutions above [XGA/WXGA](https://en.wikipedia.org/wiki/Display_resolution_standards#XGA) to avoid issues related to [image resizing](https://docs.anthropic.com/en/docs/build-with-claude/vision#evaluate-image-size).
 Relying on the image resizing behavior in the API will result in lower model accuracy and slower performance than implementing scaling in your tools directly. The `computer` tool implementation in this project demonstrates how to scale both images and coordinates from higher resolutions to the suggested resolutions.
 

--- a/computer-use-demo/computer_use_demo/streamlit.py
+++ b/computer-use-demo/computer_use_demo/streamlit.py
@@ -126,6 +126,9 @@ def setup_state():
         st.session_state.token_efficient_tools_beta = False
     if "in_sampling_loop" not in st.session_state:
         st.session_state.in_sampling_loop = False
+    # Check if thinking should be enabled via environment variable
+    if "thinking" not in st.session_state:
+        st.session_state.thinking = os.getenv("ENABLE_THINKING", "").lower() in ["true", "1", "yes"]
 
 
 def _reset_model():
@@ -214,7 +217,7 @@ async def main():
 
         st.number_input("Max Output Tokens", key="output_tokens", step=1)
 
-        st.checkbox("Thinking Enabled", key="thinking", value=False)
+        st.checkbox("Thinking Enabled", key="thinking", value=st.session_state.get("thinking", False))
         st.number_input(
             "Thinking Budget",
             key="thinking_budget",

--- a/computer-use-demo/terraform/.gitignore
+++ b/computer-use-demo/terraform/.gitignore
@@ -1,0 +1,27 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used for local settings
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Exclude lock files (optional, some teams prefer to version control this)
+.terraform.lock.hcl 

--- a/computer-use-demo/terraform/README.md
+++ b/computer-use-demo/terraform/README.md
@@ -42,9 +42,17 @@ terraform apply
 # SSH directly to the instance
 ssh -i your-private-key.pem ubuntu@<instance_public_ip>
 
-# Create SSH tunnel for the Claude interface
-ssh -L 8080:localhost:8080 -i your-private-key.pem ubuntu@<instance_public_ip>
+# IMPORTANT: Create SSH tunnel for ALL required services (RECOMMENDED METHOD)
+ssh -i your-private-key.pem -L 8080:localhost:8080 -L 6080:localhost:6080 -L 5900:localhost:5900 -L 8501:localhost:8501 -N ubuntu@<instance_public_ip>
 ```
+
+This command tunnels all necessary ports:
+- 8080: Main Claude interface
+- 6080: noVNC web interface
+- 5900: VNC direct connection
+- 8501: Streamlit interface
+
+The `-N` flag prevents opening a shell and is useful for just forwarding ports.
 
 7. Access the Claude interface at http://localhost:8080
 

--- a/computer-use-demo/terraform/README.md
+++ b/computer-use-demo/terraform/README.md
@@ -43,7 +43,7 @@ terraform apply
 ssh -i your-private-key.pem ubuntu@<instance_public_ip>
 
 # IMPORTANT: Create SSH tunnel for ALL required services (RECOMMENDED METHOD)
-ssh -i your-private-key.pem -L 8080:localhost:8080 -L 6080:localhost:6080 -L 5900:localhost:5900 -L 8501:localhost:8501 -N ubuntu@<instance_public_ip>
+ssh -i your-private-key.pem -L 8080:127.0.0.1:8080 -L 6080:127.0.0.1:6080 -L 5900:127.0.0.1:5900 -L 8501:127.0.0.1:8501 -N ubuntu@<instance_public_ip>
 ```
 
 This command tunnels all necessary ports:

--- a/computer-use-demo/terraform/README.md
+++ b/computer-use-demo/terraform/README.md
@@ -1,0 +1,84 @@
+# Claude Computer Use Demo Terraform Module
+
+This Terraform module deploys the Anthropic Claude Computer Use Demo on AWS EC2.
+
+## Prerequisites
+
+- [Terraform](https://www.terraform.io/downloads) installed (version 1.2.0 or newer)
+- AWS CLI configured with appropriate credentials
+- Anthropic API key
+
+## Usage
+
+1. Create a `terraform.tfvars` file based on the provided example:
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+2. Edit the `terraform.tfvars` file to include your SSH public key and Anthropic API key.
+
+3. Initialize Terraform:
+
+```bash
+terraform init
+```
+
+4. Preview the changes:
+
+```bash
+terraform plan
+```
+
+5. Apply the changes:
+
+```bash
+terraform apply
+```
+
+6. After successful deployment, use the outputs to connect to your EC2 instance:
+
+```bash
+# SSH directly to the instance
+ssh -i your-private-key.pem ubuntu@<instance_public_ip>
+
+# Create SSH tunnel for the Claude interface
+ssh -L 8080:localhost:8080 -i your-private-key.pem ubuntu@<instance_public_ip>
+```
+
+7. Access the Claude interface at http://localhost:8080
+
+## Notes
+
+- The EC2 instance type is set to t3.large, which should be sufficient for running the Claude Computer Use Demo.
+- The instance will have Docker pre-installed and the Claude container will start automatically on boot.
+- Make sure your private key corresponds to the public key provided in terraform.tfvars.
+
+## Cleanup
+
+To destroy all created resources:
+
+```bash
+# Navigate to the terraform directory
+cd computer-use-demo/terraform
+
+# Run the destroy command
+terraform destroy
+```
+
+This command will:
+1. Show a plan of what resources will be destroyed
+2. Ask for confirmation (type 'yes' to proceed)
+3. Remove all AWS resources created by this Terraform configuration including:
+   - EC2 instance
+   - Security groups
+   - Network resources
+   - Any other associated components
+
+Once completed, all resources and associated costs will be fully terminated.
+
+## Cost Estimation
+
+- t3.large on-demand: ~$60-75/month (running 24/7)
+- With scheduled stopping during non-working hours: ~$20-30/month
+- Additional costs for storage (~$3/month) and network traffic 

--- a/computer-use-demo/terraform/main.tf
+++ b/computer-use-demo/terraform/main.tf
@@ -1,0 +1,144 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = ">= 1.2.0"
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+}
+
+resource "aws_vpc" "claude_vpc" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "claude-vpc"
+  }
+}
+
+resource "aws_subnet" "claude_subnet" {
+  vpc_id                  = aws_vpc.claude_vpc.id
+  cidr_block              = "10.0.1.0/24"
+  map_public_ip_on_launch = true
+  availability_zone       = "${var.aws_region}a"
+
+  tags = {
+    Name = "claude-subnet"
+  }
+}
+
+resource "aws_internet_gateway" "claude_igw" {
+  vpc_id = aws_vpc.claude_vpc.id
+
+  tags = {
+    Name = "claude-igw"
+  }
+}
+
+resource "aws_route_table" "claude_route_table" {
+  vpc_id = aws_vpc.claude_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.claude_igw.id
+  }
+
+  tags = {
+    Name = "claude-route-table"
+  }
+}
+
+resource "aws_route_table_association" "claude_rta" {
+  subnet_id      = aws_subnet.claude_subnet.id
+  route_table_id = aws_route_table.claude_route_table.id
+}
+
+resource "aws_security_group" "claude_sg" {
+  name        = "claude-security-group"
+  description = "Security group for Claude Computer Use Demo"
+  vpc_id      = aws_vpc.claude_vpc.id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "SSH"
+  }
+
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Claude interface"
+  }
+
+  ingress {
+    from_port   = 8501
+    to_port     = 8501
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Streamlit"
+  }
+
+  ingress {
+    from_port   = 5900
+    to_port     = 5900
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "VNC"
+  }
+
+  ingress {
+    from_port   = 6080
+    to_port     = 6080
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "noVNC"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "claude-security-group"
+  }
+}
+
+resource "aws_key_pair" "claude_key_pair" {
+  key_name   = "claude-key"
+  public_key = var.ssh_public_key
+}
+
+resource "aws_instance" "claude_instance" {
+  ami                    = var.ami_id
+  instance_type          = "t3.2xlarge"
+  key_name               = aws_key_pair.claude_key_pair.key_name
+  vpc_security_group_ids = [aws_security_group.claude_sg.id]
+  subnet_id              = aws_subnet.claude_subnet.id
+
+  root_block_device {
+    volume_size = 20
+    volume_type = "gp3"
+  }
+
+  user_data = templatefile("${path.module}/user_data.sh", {
+    anthropic_api_key = var.anthropic_api_key
+  })
+
+  tags = {
+    Name = "claude-computer-use-demo"
+  }
+} 

--- a/computer-use-demo/terraform/outputs.tf
+++ b/computer-use-demo/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "instance_id" {
+  description = "ID of the EC2 instance"
+  value       = aws_instance.claude_instance.id
+}
+
+output "instance_public_ip" {
+  description = "Public IP address of the EC2 instance"
+  value       = aws_instance.claude_instance.public_ip
+}
+
+output "ssh_command" {
+  description = "Command to SSH into the instance"
+  value       = "ssh -i your-private-key.pem ubuntu@${aws_instance.claude_instance.public_ip}"
+}
+
+output "tunnel_command" {
+  description = "Command to create SSH tunnel for accessing the Claude interface"
+  value       = "ssh -L 8080:localhost:8080 -i your-private-key.pem ubuntu@${aws_instance.claude_instance.public_ip}"
+}
+
+output "browser_url" {
+  description = "URL to access Claude interface after creating the SSH tunnel"
+  value       = "http://localhost:8080"
+} 

--- a/computer-use-demo/terraform/terraform.tfvars.example
+++ b/computer-use-demo/terraform/terraform.tfvars.example
@@ -1,0 +1,7 @@
+aws_region        = "us-west-2"
+aws_profile       = "default"    # Here you can specify your AWS profile name
+ami_id           = "ami-03f8acd418785369b" # Ubuntu 22.04 LTS in us-west-2
+
+# IMPORTANT: Replace these values with your actual credentials before running terraform apply
+ssh_public_key   = "ssh-rsa AAAA..." # Replace with your public key
+anthropic_api_key = "sk-ant-..." # Replace with your Anthropic API key 

--- a/computer-use-demo/terraform/user_data.sh
+++ b/computer-use-demo/terraform/user_data.sh
@@ -44,14 +44,29 @@ cat > /home/ubuntu/start-claude.sh <<'EOF'
 
 export ANTHROPIC_API_KEY=${anthropic_api_key}
 
-# Run the Claude container
+# Clone the repository if it doesn't exist
+if [ ! -d "/home/ubuntu/anthropic-quickstarts" ]; then
+  echo "Cloning repository..."
+  git clone https://github.com/kirill-markin/anthropic-quickstarts.git /home/ubuntu/anthropic-quickstarts
+fi
+
+# Navigate to the computer-use-demo directory
+cd /home/ubuntu/anthropic-quickstarts/computer-use-demo
+
+# Build the Docker image locally
+echo "Building Docker image from local code..."
+docker build -t claude-computer-use:local .
+
+# Run the Claude container from the locally built image
 # Note: Using -d instead of -it for server deployment (runs in background)
 # Added --name for better server-side container management
 # IMPORTANT: The --restart unless-stopped flag is removed for debugging purposes
 # For production use, add the following line before --name claude:
 #     --restart unless-stopped \
+echo "Starting container from locally built image..."
 docker run \
     -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
+    -e ENABLE_THINKING=true \
     -v /home/ubuntu/.anthropic:/home/computeruse/.anthropic \
     -p 5900:5900 \
     -p 8501:8501 \
@@ -61,7 +76,7 @@ docker run \
     -e HEIGHT=1080 \
     -d \
     --name claude \
-    ghcr.io/anthropics/anthropic-quickstarts:computer-use-demo-latest
+    claude-computer-use:local
 EOF
 
 chmod +x /home/ubuntu/start-claude.sh

--- a/computer-use-demo/terraform/user_data.sh
+++ b/computer-use-demo/terraform/user_data.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -e
+
+# Update system packages
+apt-get update
+apt-get upgrade -y
+
+# Install required dependencies
+apt-get install -y \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release \
+    unzip
+
+# Add Docker's official GPG key
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+# Set up the Docker repository
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Install Docker Engine
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+# Add ubuntu user to docker group
+usermod -aG docker ubuntu
+
+# Install AWS CLI
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+./aws/install
+
+# Create directory for Anthropic settings
+mkdir -p /home/ubuntu/.anthropic
+chown -R ubuntu:ubuntu /home/ubuntu/.anthropic
+
+# Create the container startup script
+cat > /home/ubuntu/start-claude.sh <<'EOF'
+#!/bin/bash
+
+export ANTHROPIC_API_KEY=${anthropic_api_key}
+
+# Run the Claude container
+docker run \
+    -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
+    -v /home/ubuntu/.anthropic:/home/computeruse/.anthropic \
+    -p 5900:5900 \
+    -p 8501:8501 \
+    -p 6080:6080 \
+    -p 8080:8080 \
+    -e WIDTH=1920 \
+    -e HEIGHT=1080 \
+    -d \
+    --restart unless-stopped \
+    --name claude \
+    ghcr.io/anthropics/anthropic-quickstarts:computer-use-demo-latest
+EOF
+
+chmod +x /home/ubuntu/start-claude.sh
+chown ubuntu:ubuntu /home/ubuntu/start-claude.sh
+
+# Set up systemd service for automatic start
+cat > /etc/systemd/system/claude.service <<EOF
+[Unit]
+Description=Claude Computer Use Demo
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=ubuntu
+ExecStart=/home/ubuntu/start-claude.sh
+ExecStop=docker stop claude
+ExecStopPost=docker rm claude
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start the Claude service
+systemctl enable claude.service
+systemctl start claude.service
+
+echo "Claude Computer Use Demo setup complete" 

--- a/computer-use-demo/terraform/user_data.sh
+++ b/computer-use-demo/terraform/user_data.sh
@@ -45,6 +45,11 @@ cat > /home/ubuntu/start-claude.sh <<'EOF'
 export ANTHROPIC_API_KEY=${anthropic_api_key}
 
 # Run the Claude container
+# Note: Using -d instead of -it for server deployment (runs in background)
+# Added --name for better server-side container management
+# IMPORTANT: The --restart unless-stopped flag is removed for debugging purposes
+# For production use, add the following line before --name claude:
+#     --restart unless-stopped \
 docker run \
     -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
     -v /home/ubuntu/.anthropic:/home/computeruse/.anthropic \
@@ -55,7 +60,6 @@ docker run \
     -e WIDTH=1920 \
     -e HEIGHT=1080 \
     -d \
-    --restart unless-stopped \
     --name claude \
     ghcr.io/anthropics/anthropic-quickstarts:computer-use-demo-latest
 EOF

--- a/computer-use-demo/terraform/variables.tf
+++ b/computer-use-demo/terraform/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  description = "AWS region to deploy the infrastructure"
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "aws_profile" {
+  description = "AWS CLI profile to use for authentication"
+  type        = string
+  default     = "default"
+}
+
+variable "ami_id" {
+  description = "AMI ID for Ubuntu 22.04"
+  type        = string
+  default     = "ami-0ee5b2a8d3fa27713" # Ubuntu 22.04 LTS in us-west-2, update accordingly for other regions
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key for EC2 instance access"
+  type        = string
+  sensitive   = true
+}
+
+variable "anthropic_api_key" {
+  description = "Anthropic API key for Claude"
+  type        = string
+  sensitive   = true
+} 


### PR DESCRIPTION
This PR adds Terraform configuration for deploying the Claude Computer Use Demo on AWS EC2.

- Complete IaC setup for AWS deployment
- Configuration for EC2 instance with appropriate resources
- Network and security group configurations
- Documentation for deployment process